### PR TITLE
change forwarded-tcpip response to use ip address

### DIFF
--- a/ssh/session.go
+++ b/ssh/session.go
@@ -361,7 +361,7 @@ func (s *Session) DialContext(ctx context.Context, network, address string) (net
 	}
 
 	channel, reqs, err := s.secureConn.OpenChannel("forwarded-tcpip", ssh.Marshal(directTCPIP{
-		Addr:  "localhost",
+		Addr:  "127.0.0.1",
 		Rport: uint32(p),
 	}))
 


### PR DESCRIPTION
I've been trying to use this with a go-based client and have ran into an issue. The [go standard library](https://github.com/golang/crypto/blob/master/ssh/tcpip.go#L211)/RFC 4254 assume that the `forwardedtcp-ip` is an ip address, but it's a host so the responses are [rejected](https://github.com/golang/crypto/blob/master/ssh/tcpip.go#L216)

This pr changes the return to be a localhost
